### PR TITLE
Update PGB Roster to include new members

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,12 @@ It is overseen by the Ethereum OASIS Project Governing Board:
 
 * Daniel Burnett, Enterprise Ethereum Alliance ([@burnburn](https://github.com/burnburn))
 * Tas Dienes, Ethereum Foundation ([@tasdienes](https://github.com/tasdienes))
+* Dan Kochis, Chainlink ([@dk21dk](https://github.com/dk21dk))
+* Tracy Kuhrt, Accenture ([@tkuhrt](https://github.com/tkuhrt))
 * Chaals Nevile, ConsenSys ([@chaals](https://github.com/chaals))
 * Gina Rubino, Nethermind ([@grubino28](https://github.com/grubino28))
 * Stefan Schmidt, Unibright ([@stefschmidt](https://github.com/stefschmidt))
+* Kyle Thomas, Provide ([@kthomas](https://github.com/kthomas))
 * John Wolpert, Baseline TSC Chair ([@humbitious](https://github.com/humbitious))
 
 For information on joining sponsoring these projects or joining the governing board, please contact [Jory Burson](https://github.com/jorydotcom), OASIS Open Projects Program Manager, or email [op-admin@oasis-open.org]().


### PR DESCRIPTION
Adds representatives from Accenture, Chainlink, and Provide, who have signed the ECLA.